### PR TITLE
chore: remove unused lib.removeNewline and lib.secretManager functions (Vibe Kanban)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -7,12 +7,10 @@
 # INTEGRATION:
 # - Imported by lib/overlays.nix
 # - Extended into pkgs.lib via libOverlay
-# - Available as lib.exe, lib.removeNewline, lib.secretManager everywhere
+# - Available as lib.exe everywhere
 #
-# USAGE EXAMPLES:
+# USAGE EXAMPLE:
 # - lib.exe pkgs.zsh => "/nix/store/.../bin/zsh"
-# - lib.removeNewline fileContents
-# - lib.secretManager.readSecret "~/.secrets/token"
 # =============================================================================
 { lib }:
 
@@ -38,48 +36,4 @@
   #   Used in: sessionVariables.SHELL = "${lib.exe pkgs.zsh}";
   # ---------------------------------------------------------------------------
   exe = pkg: "${lib.getBin pkg}/bin/${pkg.pname or pkg.name}";
-
-  # ---------------------------------------------------------------------------
-  # STRING CLEANING UTILITIES
-  # ---------------------------------------------------------------------------
-  # Removes trailing newline character from strings
-  #
-  # USE CASES:
-  # - Cleaning output from readFile that includes trailing newlines
-  # - Processing command output that ends with \n
-  # - Preparing strings for concatenation
-  #
-  # PARAMETERS:
-  # - str: String to clean
-  #
-  # RETURNS:
-  # - String without trailing newline
-  #
-  # EXAMPLE:
-  #   lib.removeNewline "hello\n" => "hello"
-  # ---------------------------------------------------------------------------
-  removeNewline = str: lib.strings.removeSuffix "\n" str;
-
-  # ---------------------------------------------------------------------------
-  # SECRET MANAGEMENT
-  # ---------------------------------------------------------------------------
-  # Provides functions for reading secrets from files
-  #
-  # SECURITY CONSIDERATIONS:
-  # - Secrets read this way are stored in the Nix store (world-readable!)
-  # - Only use for non-critical secrets or during development
-  # - For production, consider: sops-nix, agenix, or vault integration
-  #
-  # USAGE:
-  #   programs.git.userEmail = lib.secretManager.readSecret "./secrets/email";
-  #
-  # FUTURE ENHANCEMENTS:
-  # - Could integrate with sops-nix for encrypted secrets
-  # - Could add runtime secret injection via systemd
-  # ---------------------------------------------------------------------------
-  secretManager = {
-    # Read a secret from a file path
-    # WARNING: Result will be in Nix store (world-readable)
-    readSecret = path: builtins.readFile path;
-  };
 }

--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -5,9 +5,8 @@
 # They allow us to add custom packages, modify existing ones, and inject utilities
 #
 # OVERLAY ARCHITECTURE:
-# 1. libOverlay: Extends pkgs.lib with custom utility functions
+# 1. libOverlay: Extends pkgs.lib with lib.exe utility function
 # 2. overlays: Adds builder functions for creating configurations
-# 3. niri-flake overlay: Adds niri-unstable package from upstream
 #
 # HOW OVERLAYS WORK:
 # - f (final): The final package set after all overlays are applied
@@ -39,11 +38,11 @@ let
   #
   # WHAT IT DOES:
   # 1. Imports ./default.nix (our custom lib functions)
-  # 2. Extends pkgs.lib to include: exe, removeNewline, secretManager
+  # 2. Extends pkgs.lib to include: exe
   # 3. Applies version overlay for nixos-version support
   #
   # RESULT:
-  # - All Nix files can use lib.exe, lib.removeNewline, etc.
+  # - All Nix files can use lib.exe
   # - Version information is properly tracked
   #
   # OVERLAY PATTERN:
@@ -56,7 +55,7 @@ let
     
     # Extend nixpkgs lib with our custom functions and version info
     lib = (p.lib.extend (_: _: {
-      inherit (libx) exe removeNewline secretManager;
+      inherit (libx) exe;
     })).extend libVersionOverlay;
   };
 
@@ -117,7 +116,7 @@ in
 # OVERLAY LIST
 # =============================================================================
 # Overlays are applied in order:
-# 1. libOverlay: Adds custom lib functions (exe, removeNewline, etc.)
+# 1. libOverlay: Adds lib.exe function
 # 2. overlays: Adds builder functions (mkHome, mkNixos)
 # 3. niri-flake overlay: Adds niri-unstable package
 #

--- a/lib/schemas.nix
+++ b/lib/schemas.nix
@@ -54,7 +54,7 @@
       - overlays: Our overlay functions for extending nixpkgs
       
       External flakes can consume these to gain access to:
-      - Custom library functions (lib.exe, lib.secretManager, etc.)
+      - Custom library functions (lib.exe)
       - Builder functions (mkHome, mkNixos)
       - Niri unstable package
     '';


### PR DESCRIPTION
## Summary

Remove unused custom library functions from the Nix configuration to reduce dead code and simplify the codebase.

## Changes

### Removed Functions

- **`lib.removeNewline`** - String utility for removing trailing newlines (never used)
- **`lib.secretManager`** - Secret file reader (never used, also had security concerns about Nix store visibility)

### Files Modified

1. **`lib/default.nix`** (-46 lines)
   - Removed `removeNewline` function definition and documentation
   - Removed `secretManager` attrset and documentation
   - Updated header comments to reflect only `lib.exe` is available

2. **`lib/overlays.nix`** (-3 lines)
   - Changed inherit statement from `inherit (libx) exe removeNewline secretManager;` to `inherit (libx) exe;`
   - Updated documentation comments throughout to remove references to removed functions

3. **`lib/schemas.nix`** (1 line)
   - Updated external API documentation to reflect only `lib.exe` is exported

## Rationale

These functions were defined but never used anywhere in the codebase. Keeping `lib.exe` which is actively used in 3 locations for generating executable paths from packages.

## Verification

- ✅ `rg "removeNewline|secretManager"` returns no matches
- ✅ `nix build .#homeConfigurations.niri.activationPackage` builds successfully
- ✅ `nix build .#nixosConfigurations.arasaka.config.system.build.toplevel` builds successfully

---

This PR was written using [Vibe Kanban](https://vibekanban.com)